### PR TITLE
Updated example code to register a table view cell subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class MyTableViewController: CoreDataTableViewController {
 
 	override func viewDidLoad() {
 	    super.viewDidLoad()
-	    
+	    tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "Cell")
 	    refreshData()
 	}
 


### PR DESCRIPTION
Great work on the project! I've updated the README to reflect the need to register a `UITableViewCell` subclass on the table view otherwise it will crash as it's unable to dequeue a cell.
