### PR TITLE
Swift 3 migration

### DIFF
--- a/AECoreDataUI.xcodeproj/project.pbxproj
+++ b/AECoreDataUI.xcodeproj/project.pbxproj
@@ -180,14 +180,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = AE;
 				TargetAttributes = {
 					8BFD96E11CF073F8008E8C9E = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					8BFD96EB1CF073F8008E8C9E = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -268,8 +270,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -317,8 +321,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -338,6 +344,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -350,6 +357,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -361,6 +369,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -369,6 +378,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -379,6 +389,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.tadija.AECoreDataUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -389,6 +400,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.tadija.AECoreDataUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -399,6 +411,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = net.tadija.AECoreDataUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -421,6 +434,7 @@
 				8BFD96F81CF073F8008E8C9E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		8BFD96F91CF073F8008E8C9E /* Build configuration list for PBXNativeTarget "AECoreDataUITests" */ = {
 			isa = XCConfigurationList;
@@ -429,6 +443,7 @@
 				8BFD96FB1CF073F8008E8C9E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/AECoreDataUI.xcodeproj/xcshareddata/xcschemes/AECoreDataUI.xcscheme
+++ b/AECoreDataUI.xcodeproj/xcshareddata/xcschemes/AECoreDataUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/AECoreDataUI.swift
+++ b/Sources/AECoreDataUI.swift
@@ -41,10 +41,10 @@ import UIKit
     If you want new fetch parameters (predicate, sorting, etc.),
     create a **NEW** `NSFetchedResultsController` and set this class's `fetchedResultsController` property again.
 */
-open class CoreDataTableViewController<T: NSFetchRequestResult>: UITableViewController, NSFetchedResultsControllerDelegate {
+open class CoreDataTableViewController: UITableViewController, NSFetchedResultsControllerDelegate {
     
     /// The controller *(this class fetches nothing if this is not set)*.
-    open var fetchedResultsController: NSFetchedResultsController<T>? {
+    open var fetchedResultsController: NSFetchedResultsController<NSManagedObject>? {
         didSet {
             if let frc = fetchedResultsController {
                 if frc != oldValue {

--- a/Sources/AECoreDataUI.swift
+++ b/Sources/AECoreDataUI.swift
@@ -270,10 +270,10 @@ open class CoreDataTableViewController: UITableViewController, NSFetchedResultsC
     If you want new fetch parameters (predicate, sorting, etc.),
     create a **NEW** `NSFetchedResultsController` and set this class's `fetchedResultsController` property again.
 */
-open class CoreDataCollectionViewController<T: NSFetchRequestResult>: UICollectionViewController, NSFetchedResultsControllerDelegate {
+open class CoreDataCollectionViewController: UICollectionViewController, NSFetchedResultsControllerDelegate {
     
     /// The controller *(this class fetches nothing if this is not set)*.
-    open var fetchedResultsController: NSFetchedResultsController<T>? {
+    open var fetchedResultsController: NSFetchedResultsController<NSManagedObject>? {
         didSet {
             if let frc = fetchedResultsController {
                 if frc != oldValue {

--- a/Sources/AECoreDataUI.swift
+++ b/Sources/AECoreDataUI.swift
@@ -41,10 +41,10 @@ import UIKit
     If you want new fetch parameters (predicate, sorting, etc.),
     create a **NEW** `NSFetchedResultsController` and set this class's `fetchedResultsController` property again.
 */
-public class CoreDataTableViewController: UITableViewController, NSFetchedResultsControllerDelegate {
+open class CoreDataTableViewController<T: NSFetchRequestResult>: UITableViewController, NSFetchedResultsControllerDelegate {
     
     /// The controller *(this class fetches nothing if this is not set)*.
-    public var fetchedResultsController: NSFetchedResultsController? {
+    open var fetchedResultsController: NSFetchedResultsController<T>? {
         didSet {
             if let frc = fetchedResultsController {
                 if frc != oldValue {
@@ -69,7 +69,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         since the `NSFetchedResultsController` will notice and update the table automatically).
         This will also automatically be called if you change the `fetchedResultsController` property.
     */
-    public func performFetch() throws {
+    open func performFetch() throws {
         if let frc = fetchedResultsController {
             defer {
                 tableView.reloadData()
@@ -82,7 +82,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         }
     }
     
-    private var _suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool = false
+    fileprivate var _suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool = false
     /**
         Turn this on before making any changes in the managed object context that
         are a one-for-one result of the user manipulating rows directly in the table view.
@@ -98,7 +98,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         It is not necessary (in fact, not desirable) to set this during row deletion or insertion
         (but definitely for row moves).
     */
-    public var suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool {
+    open var suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool {
         get {
             return _suspendAutomaticTrackingOfChangesInManagedObjectContext
         }
@@ -106,11 +106,13 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
             if newValue == true {
                 _suspendAutomaticTrackingOfChangesInManagedObjectContext = true
             } else {
-                dispatch_after(0, dispatch_get_main_queue(), { self._suspendAutomaticTrackingOfChangesInManagedObjectContext = false })
+                DispatchQueue.main.asyncAfter(deadline: .now()) {
+                    self._suspendAutomaticTrackingOfChangesInManagedObjectContext = false
+                }
             }
         }
     }
-    private var beganUpdates: Bool = false
+    fileprivate var beganUpdates: Bool = false
     
     // MARK: NSFetchedResultsControllerDelegate
     
@@ -119,7 +121,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :param: controller The fetched results controller that sent the message.
     */
-    public func controllerWillChangeContent(controller: NSFetchedResultsController) {
+    open func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         if !suspendAutomaticTrackingOfChangesInManagedObjectContext {
             tableView.beginUpdates()
             beganUpdates = true
@@ -134,13 +136,14 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         :param: sectionIndex The index of the changed section.
         :param: type The type of change (insert or delete).
     */
-    public func controller(controller: NSFetchedResultsController, didChangeSection sectionInfo: NSFetchedResultsSectionInfo, atIndex sectionIndex: Int, forChangeType type: NSFetchedResultsChangeType) {
+    open func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange sectionInfo: NSFetchedResultsSectionInfo, atSectionIndex sectionIndex: Int, for type: NSFetchedResultsChangeType) {
         if !suspendAutomaticTrackingOfChangesInManagedObjectContext {
+            let sectionIndex = IndexSet(integer: sectionIndex)
             switch type {
-            case .Insert:
-                tableView.insertSections(NSIndexSet(index: sectionIndex), withRowAnimation: .Fade)
-            case .Delete:
-                tableView.deleteSections(NSIndexSet(index: sectionIndex), withRowAnimation: .Fade)
+            case .insert:
+                tableView.insertSections(sectionIndex, with: .fade)
+            case .delete:
+                tableView.deleteSections(sectionIndex, with: .fade)
             default:
                 return
             }
@@ -156,20 +159,20 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         :param: type The type of change.
         :param: newIndexPath The destination path for the object for insertions or moves (this value is nil for a deletion).
     */
-    public func controller(controller: NSFetchedResultsController, didChangeObject anObject: AnyObject, atIndexPath indexPath: NSIndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: NSIndexPath?) {
+    open func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
         if !suspendAutomaticTrackingOfChangesInManagedObjectContext {
             switch type {
-            case .Insert:
-                tableView.insertRowsAtIndexPaths([newIndexPath!], withRowAnimation: .Fade)
-            case .Delete:
-                tableView.deleteRowsAtIndexPaths([indexPath!], withRowAnimation: .Fade)
-            case .Update:
-                tableView.reloadRowsAtIndexPaths([indexPath!], withRowAnimation: .Fade)
-            case .Move:
+            case .insert:
+                tableView.insertRows(at: [newIndexPath!], with: .fade)
+            case .delete:
+                tableView.deleteRows(at: [indexPath!], with: .fade)
+            case .update:
+                tableView.reloadRows(at: [indexPath!], with: .fade)
+            case .move:
                 // TODO: fix bug when moving rows in iOS 8.3 and 8.4 - Xcode 7.0 (7A220)
                 // SEE: http://stackoverflow.com/questions/31383760/ios-9-attempt-to-delete-and-reload-the-same-index-path
-                tableView.deleteRowsAtIndexPaths([indexPath!], withRowAnimation: .Fade)
-                tableView.insertRowsAtIndexPaths([newIndexPath!], withRowAnimation: .Fade)
+                tableView.deleteRows(at: [indexPath!], with: .fade)
+                tableView.insertRows(at: [newIndexPath!], with: .fade)
             }
         }
     }
@@ -179,7 +182,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :param: controller The fetched results controller that sent the message.
     */
-    public func controllerDidChangeContent(controller: NSFetchedResultsController) {
+    open func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         if beganUpdates {
             tableView.endUpdates()
         }
@@ -194,8 +197,8 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :returns: The number of sections in tableView.
     */
-    public override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        let superNumberOfSections = super.numberOfSectionsInTableView(tableView)
+    open override func numberOfSections(in tableView: UITableView) -> Int {
+        let superNumberOfSections = super.numberOfSections(in: tableView)
         return fetchedResultsController?.sections?.count ?? superNumberOfSections
     }
     
@@ -207,7 +210,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :returns: The number of rows in section.
     */
-    public override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let superNumberOfRows = super.tableView(tableView, numberOfRowsInSection: section)
         return (fetchedResultsController?.sections?[section])?.numberOfObjects ?? superNumberOfRows
     }
@@ -220,7 +223,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :returns: A string to use as the title of the section header.
     */
-    public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let superTitleForHeader = super.tableView(tableView, titleForHeaderInSection: section)
         return (fetchedResultsController?.sections?[section])?.name ?? superTitleForHeader
     }
@@ -234,8 +237,8 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :returns: An index number identifying a section.
     */
-    public override func tableView(tableView: UITableView, sectionForSectionIndexTitle title: String, atIndex index: Int) -> Int {
-        return fetchedResultsController?.sectionForSectionIndexTitle(title, atIndex: index) ?? 0
+    open override func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
+        return fetchedResultsController?.section(forSectionIndexTitle: title, at: index) ?? 0
     }
     
     /**
@@ -245,7 +248,7 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
         
         :returns: An array of strings that serve as the title of sections in the table view and appear in the index list on the right side of the table view.
     */
-    public override func sectionIndexTitlesForTableView(tableView: UITableView) -> [String]? {
+    open override func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         return fetchedResultsController?.sectionIndexTitles
     }
     
@@ -267,10 +270,10 @@ public class CoreDataTableViewController: UITableViewController, NSFetchedResult
     If you want new fetch parameters (predicate, sorting, etc.),
     create a **NEW** `NSFetchedResultsController` and set this class's `fetchedResultsController` property again.
 */
-public class CoreDataCollectionViewController: UICollectionViewController, NSFetchedResultsControllerDelegate {
+open class CoreDataCollectionViewController<T: NSFetchRequestResult>: UICollectionViewController, NSFetchedResultsControllerDelegate {
     
     /// The controller *(this class fetches nothing if this is not set)*.
-    public var fetchedResultsController: NSFetchedResultsController? {
+    open var fetchedResultsController: NSFetchedResultsController<T>? {
         didSet {
             if let frc = fetchedResultsController {
                 if frc != oldValue {
@@ -295,7 +298,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         since the `NSFetchedResultsController` will notice and update the collection view automatically).
         This will also automatically be called if you change the `fetchedResultsController` property.
     */
-    public func performFetch() throws {
+    open func performFetch() throws {
         if let frc = fetchedResultsController {
             defer {
                 collectionView?.reloadData()
@@ -308,7 +311,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         }
     }
     
-    private var _suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool = false
+    fileprivate var _suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool = false
     /**
         Turn this on before making any changes in the managed object context that
         are a one-for-one result of the user manipulating cells directly in the collection view.
@@ -324,7 +327,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         It is not necessary (in fact, not desirable) to set this during row deletion or insertion
         (but definitely for cell moves).
     */
-    public var suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool {
+    open var suspendAutomaticTrackingOfChangesInManagedObjectContext: Bool {
         get {
             return _suspendAutomaticTrackingOfChangesInManagedObjectContext
         }
@@ -332,64 +335,66 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
             if newValue == true {
                 _suspendAutomaticTrackingOfChangesInManagedObjectContext = true
             } else {
-                dispatch_after(0, dispatch_get_main_queue(), { self._suspendAutomaticTrackingOfChangesInManagedObjectContext = false })
+                DispatchQueue.main.asyncAfter(deadline: .now()) {
+                    self._suspendAutomaticTrackingOfChangesInManagedObjectContext = false
+                }
             }
         }
     }
     
     // MARK: NSFetchedResultsControllerDelegate Helpers
     
-    private var sectionInserts = [Int]()
-    private var sectionDeletes = [Int]()
-    private var sectionUpdates = [Int]()
+    fileprivate var sectionInserts = [Int]()
+    fileprivate var sectionDeletes = [Int]()
+    fileprivate var sectionUpdates = [Int]()
     
-    private var objectInserts = [NSIndexPath]()
-    private var objectDeletes = [NSIndexPath]()
-    private var objectUpdates = [NSIndexPath]()
-    private var objectMoves = [NSIndexPath]()
-    private var objectReloads = Set<NSIndexPath>()
+    fileprivate var objectInserts = [IndexPath]()
+    fileprivate var objectDeletes = [IndexPath]()
+    fileprivate var objectUpdates = [IndexPath]()
+    fileprivate var objectMoves = [IndexPath]()
+    fileprivate var objectReloads = Set<IndexPath>()
     
-    private func updateSectionsAndObjects() {
+    fileprivate func updateSectionsAndObjects() {
         // sections
         if !self.sectionInserts.isEmpty {
             for sectionIndex in self.sectionInserts {
-                self.collectionView?.insertSections(NSIndexSet(index: sectionIndex))
+                self.collectionView?.insertSections(IndexSet(integer: sectionIndex))
             }
-            self.sectionInserts.removeAll(keepCapacity: true)
+            self.sectionInserts.removeAll(keepingCapacity: true)
         }
         if !self.sectionDeletes.isEmpty {
             for sectionIndex in self.sectionDeletes {
-                self.collectionView?.deleteSections(NSIndexSet(index: sectionIndex))
+                self.collectionView?.deleteSections(IndexSet(integer: sectionIndex))
             }
-            self.sectionDeletes.removeAll(keepCapacity: true)
+            self.sectionDeletes.removeAll(keepingCapacity: true)
         }
         if !self.sectionUpdates.isEmpty {
             for sectionIndex in self.sectionUpdates {
-                self.collectionView?.reloadSections(NSIndexSet(index: sectionIndex))
+                self.collectionView?.reloadSections(IndexSet(integer: sectionIndex))
             }
-            self.sectionUpdates.removeAll(keepCapacity: true)
+            self.sectionUpdates.removeAll(keepingCapacity: true)
         }
         // objects
         if !self.objectInserts.isEmpty {
-            self.collectionView?.insertItemsAtIndexPaths(self.objectInserts)
-            self.objectInserts.removeAll(keepCapacity: true)
+            self.collectionView?.insertItems(at: self.objectInserts)
+            self.objectInserts.removeAll(keepingCapacity: true)
         }
         if !self.objectDeletes.isEmpty {
-            self.collectionView?.deleteItemsAtIndexPaths(self.objectDeletes)
-            self.objectDeletes.removeAll(keepCapacity: true)
+            self.collectionView?.deleteItems(at: self.objectDeletes)
+            self.objectDeletes.removeAll(keepingCapacity: true)
         }
         if !self.objectUpdates.isEmpty {
-            self.collectionView?.reloadItemsAtIndexPaths(self.objectUpdates)
-            self.objectUpdates.removeAll(keepCapacity: true)
+            self.collectionView?.reloadItems(at: self.objectUpdates)
+            self.objectUpdates.removeAll(keepingCapacity: true)
         }
         if !self.objectMoves.isEmpty {
             let moveOperations = objectMoves.count / 2
             var index = 0
             for _ in 0 ..< moveOperations {
-                self.collectionView?.moveItemAtIndexPath(self.objectMoves[index], toIndexPath: self.objectMoves[index + 1])
+                self.collectionView?.moveItem(at: self.objectMoves[index], to: self.objectMoves[index + 1])
                 index = index + 2
             }
-            self.objectMoves.removeAll(keepCapacity: true)
+            self.objectMoves.removeAll(keepingCapacity: true)
         }
     }
     
@@ -403,13 +408,13 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         :param: sectionIndex The index of the changed section.
         :param: type The type of change (insert or delete).
     */
-    public func controller(controller: NSFetchedResultsController, didChangeSection sectionInfo: NSFetchedResultsSectionInfo, atIndex sectionIndex: Int, forChangeType type: NSFetchedResultsChangeType) {
+    open func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange sectionInfo: NSFetchedResultsSectionInfo, atSectionIndex sectionIndex: Int, for type: NSFetchedResultsChangeType) {
         switch type {
-        case .Insert:
+        case .insert:
             sectionInserts.append(sectionIndex)
-        case .Delete:
+        case .delete:
             sectionDeletes.append(sectionIndex)
-        case .Update:
+        case .update:
             sectionUpdates.append(sectionIndex)
         default:
             break
@@ -425,15 +430,15 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         :param: type The type of change.
         :param: newIndexPath The destination path for the object for insertions or moves (this value is nil for a deletion).
     */
-    public func controller(controller: NSFetchedResultsController, didChangeObject anObject: AnyObject, atIndexPath indexPath: NSIndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: NSIndexPath?) {
+    open func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
         switch type {
-        case .Insert:
+        case .insert:
             objectInserts.append(newIndexPath!)
-        case .Delete:
+        case .delete:
             objectDeletes.append(indexPath!)
-        case .Update:
+        case .update:
             objectUpdates.append(indexPath!)
-        case .Move:
+        case .move:
             objectMoves.append(indexPath!)
             objectMoves.append(newIndexPath!)
             objectReloads.insert(indexPath!)
@@ -446,7 +451,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         
         :param: controller The fetched results controller that sent the message.
     */
-    public func controllerDidChangeContent(controller: NSFetchedResultsController) {
+    open func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         if !suspendAutomaticTrackingOfChangesInManagedObjectContext {
             // do batch updates on collection view
             collectionView?.performBatchUpdates({ () -> Void in
@@ -454,7 +459,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
                 }, completion: { (finished) -> Void in
                     // reload moved items when finished
                     if self.objectReloads.count > 0 {
-                        self.collectionView?.reloadItemsAtIndexPaths(Array(self.objectReloads))
+                        self.collectionView?.reloadItems(at: Array(self.objectReloads))
                         self.objectReloads.removeAll()
                     }
             })
@@ -470,7 +475,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         
         :returns: The number of sections in collectionView.
     */
-    override public func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
+    override open func numberOfSections(in collectionView: UICollectionView) -> Int {
         return fetchedResultsController?.sections?.count ?? 1
     }
     
@@ -482,7 +487,7 @@ public class CoreDataCollectionViewController: UICollectionViewController, NSFet
         
         :returns: The number of rows in section.
     */
-    override public func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    override open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         let superNumberOfItems = super.collectionView(collectionView, numberOfItemsInSection: section)
         return (fetchedResultsController?.sections?[section])?.numberOfObjects ?? superNumberOfItems
     }

--- a/Tests/AECoreDataUITests.swift
+++ b/Tests/AECoreDataUITests.swift
@@ -44,7 +44,7 @@ class AECoreDataUITests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
- Complete swift3 migration
- Due to changes in access control, I've refactored public to open and private to fileprivate
- Implemented generic types do to NSFetchResultsController becoming generic
- Changed dispatch_after(0, dispatch_get_main_queue()) to new Swift syntax DispatchQueue.main.asyncAfter(deadline: .now())
