### PR TITLE
Fix collection view reloading

### DIFF
--- a/Sources/CoreDataCollectionViewController.swift
+++ b/Sources/CoreDataCollectionViewController.swift
@@ -57,6 +57,7 @@ open class CoreDataCollectionViewController: UICollectionViewController, NSFetch
                 }
             } else {
                 collectionView?.reloadData()
+                collectionView?.collectionViewLayout.invalidateLayout()
             }
         }
     }


### PR DESCRIPTION
In iOS 10 the collection view may crash sometimes, because the layout invalidation is not triggered when reloading.
More info here: https://stackoverflow.com/a/39919303/3160561
